### PR TITLE
Respuestas del endpoint con Content-Type: application/json

### DIFF
--- a/coronapi/api.py
+++ b/coronapi/api.py
@@ -31,7 +31,7 @@ def resource_not_found(e):
 # Historical endpoints
 @bp.route(V3_HISTORICAL_NATIONAL_PATH, methods=["GET"])
 def v3_historical_national():
-    return json.dumps(get_national_data(), ensure_ascii=False)
+    return jsonify(get_national_data())
 
 
 @bp.route(V3_HISTORICAL_REGION_PATH, methods=["GET"])
@@ -41,9 +41,9 @@ def v3_historical_regions():
         id = int(request.args["id"])
         if id not in range(1, 17):
             return abort(404, description=NOT_FOUND_REGION_ERROR)
-        return json.dumps(data[str(id)], ensure_ascii=False)
+        return jsonify(data[str(id)])
 
-    return json.dumps(data, ensure_ascii=False)
+    return jsonify(data)
 
 
 @bp.route(V3_HISTORICAL_COMMUNE_PATH, methods=["GET"])
@@ -52,11 +52,11 @@ def v3_historical_communes():
     if "id" in request.args:
         id = int(request.args["id"])
         try:
-            return json.dumps(data[id], ensure_ascii=False)
+            return jsonify(data[id])
         except KeyError:
             return abort(404, description=NOT_FOUND_COMMUNE_ERROR)
 
-    return json.dumps(get_communes_data(), ensure_ascii=False)
+    return jsonify(get_communes_data())
 
 
 # latest endpoints
@@ -65,7 +65,7 @@ def v3_national_latest():
     data = get_national_data()
     max_key = max(data.keys())
 
-    return json.dumps(data[max_key], ensure_ascii=False)
+    return jsonify(data[max_key])
 
 
 @bp.route(V3_LATEST_REGIONAL_PATH, methods=["GET"])
@@ -78,8 +78,8 @@ def v3_regional_latest():
         id = int(request.args["id"])
         if id not in range(1, 17):
             return abort(404, description=NOT_FOUND_REGION_ERROR)
-        return json.dumps(data[str(id)], ensure_ascii=False)
-    return json.dumps(data, ensure_ascii=False)
+        return jsonify(data[str(id)])
+    return jsonify(data)
 
 
 @bp.route(V3_LATEST_COMMUNES_PATH, methods=["GET"])
@@ -93,11 +93,11 @@ def v3_communes_latest():
         id = int(request.args["id"])
 
         try:
-            return json.dumps(data[id], ensure_ascii=False)
+            return jsonify(data[id])
         except KeyError:
             return abort(404, description=NOT_FOUND_COMMUNE_ERROR)
 
-    return json.dumps(data, ensure_ascii=False)
+    return jsonify(data)
 
 
 # Models endpoints
@@ -114,7 +114,7 @@ def v3_models_regions():
         for attr, val in data[key]["regionInfo"].items():
             if attr in ["population", "area", "lat", "long"]:
                 data_dict[key][attr] = val
-    return json.dumps(data_dict, ensure_ascii=False)
+    return jsonify(data_dict)
 
 
 @bp.route(V3_COMMUNES, methods=["GET"])
@@ -133,4 +133,4 @@ def v3_models_communes():
         for attr, val in data[key]["communeInfo"].items():
             if attr in ["population", "area", "hdi"]:
                 data_dict[key][attr] = val 
-    return json.dumps(data_dict, ensure_ascii=False)
+    return jsonify(data_dict)


### PR DESCRIPTION
Actualmente las respuestas de los endpoint tienen en el header `Content-Type: text/html; charset=utf-8`, lo cual es incorrecto, porque las respuestas son json válidos. Para solucionarlo utilicé la función `jsonify()` de Flask en los `return` de la api.